### PR TITLE
Fixes #55

### DIFF
--- a/dnaPipeTE.py
+++ b/dnaPipeTE.py
@@ -592,7 +592,7 @@ class Blast:
             blast = "sort -k1,1 -k12,12nr -k11,11n "+self.output_folder+"/blast_out/reads_vs_unannoted.blast.out > "+self.output_folder+"/blast_out/int.reads_vs_unannoted.blast.out"
             blastProcess = subprocess.Popen(str(blast), shell=True)
             blastProcess.wait()
-            sortblast = "python3 ./blast_sorter.py --input_dir "+self.output_folder+"/blast_out/int.reads_vs_unannoted.blast.out > "+self.output_folder+"/blast_out/sorted.reads_vs_unannoted.blast.out" + " ; rm " +self.output_folder+"/blast_out/int.reads_vs_annoted.blast.out"
+            sortblast = "python3 ./blast_sorter.py --input_dir "+self.output_folder+"/blast_out/int.reads_vs_unannoted.blast.out > "+self.output_folder+"/blast_out/sorted.reads_vs_unannoted.blast.out" + " ; rm " +self.output_folder+"/blast_out/int.reads_vs_unannoted.blast.out"
             sortBlastProcess = subprocess.Popen(str(sortblast),shell=True)
             sortBlastProcess.wait()
         else:


### PR DESCRIPTION
Deletes the intermediate file `int.reads_vs_unannoted.blast.out` instead of `int.reads_vs_annoted.blast.out` at the end of the `blast3_run` function. 

The change replaces the line:
```
           sortblast = "python3 ./blast_sorter.py --input_dir "+self.output_folder+"/blast_out/int.reads_vs_unannoted.blast.out > "+self.output_folder+"/blast_out/sorted.reads_vs_unannoted.blast.out" + " ; rm " +self.output_folder+"/blast_out/int.reads_vs_annoted.blast.out"
```
with:
```
            sortblast = "python3 ./blast_sorter.py --input_dir "+self.output_folder+"/blast_out/int.reads_vs_unannoted.blast.out > "+self.output_folder+"/blast_out/sorted.reads_vs_unannoted.blast.out" + " ; rm " +self.output_folder+"/blast_out/int.reads_vs_unannoted.blast.out"
```